### PR TITLE
SSR compatibility quickfix

### DIFF
--- a/package/Menu.svelte
+++ b/package/Menu.svelte
@@ -2,15 +2,10 @@
  * Once a menu has been made visible, these events will trigger
  * the close() function
  */
-const CLOSE_LISTENERS = {
-    "click": document.body,
-    "contextmenu": document.body,
-    "scroll": document
-};
 import { onDestroy, onMount, setContext } from "svelte";
-import { writable } from "svelte/store";
-import { createStyleString, findParentWithScroll } from "./utilities";
-import { currentMenu, defaultSettings } from "./stores";
+import { get, writable } from "svelte/store";
+import { createStyleString, findParentWithScroll, assignEventTarget } from "./utilities";
+import { currentMenu, defaultSettings, CLOSE_LISTENERS } from "./stores";
 import { computeMenuStyle, getMenuClass } from "./menuUtilities";
 /** Menu Settings */
 export let settings = null;
@@ -54,7 +49,7 @@ function close(e) {
         return;
     menuPosition = null;
     Object.keys(CLOSE_LISTENERS).forEach((eventName) => {
-        const target = CLOSE_LISTENERS[eventName];
+        const target = assignEventTarget(get(CLOSE_LISTENERS)[eventName]);
         target.removeEventListener(eventName, close);
     });
     if (currentParentContainer !== null) {
@@ -90,7 +85,7 @@ export function show(clickEvent) {
     clickEvent.preventDefault();
     currentMenu.set(ref);
     Object.keys(CLOSE_LISTENERS).forEach((eventName) => {
-        const target = CLOSE_LISTENERS[eventName];
+        const target = assignEventTarget(get(CLOSE_LISTENERS)[eventName]);
         target.addEventListener(eventName, close);
     });
     // If a parent container w/ custom scrolling exists, then 

--- a/package/stores.d.ts
+++ b/package/stores.d.ts
@@ -1,3 +1,4 @@
 import Settings from "./Settings";
 export declare const currentMenu: import("svelte/store").Writable<null>;
 export declare const defaultSettings: import("svelte/store").Writable<Settings>;
+export declare const CLOSE_LISTENERS: import("svelte/store").Readable<any>;

--- a/package/stores.js
+++ b/package/stores.js
@@ -1,4 +1,9 @@
-import { writable } from "svelte/store";
+import { readable, writable } from "svelte/store";
 import Settings from "./Settings";
 export const currentMenu = writable(null);
 export const defaultSettings = writable(Settings.DefaultCss());
+export const CLOSE_LISTENERS = readable({
+	click: "document.body",
+	contextmenu: "document.body",
+	scroll: "document",
+});

--- a/package/utilities.d.ts
+++ b/package/utilities.d.ts
@@ -11,3 +11,5 @@ export declare function createStyleString(style: {
  * @returns
  */
 export declare function findParentWithScroll(clickEvent: ContextMenuMouseEvent): HTMLElement | null;
+/** Returns document element for event target string */
+export declare function assignEventTarget(targetString: String): HTMLElement | null;

--- a/package/utilities.js
+++ b/package/utilities.js
@@ -28,3 +28,14 @@ export function findParentWithScroll(clickEvent) {
     }
     return null;
 }
+/** Returns document element for event target string */
+export function assignEventTarget(targetString) {
+	switch (targetString) {
+		case "document.body":
+			return document.body;
+		case "document":
+			return document;
+		default:
+			break;
+	}
+}


### PR DESCRIPTION
Run into problems with getting it work with sveltekit ssr, so made a quickfix.

Moved EVENT_LISTENERS definition to store, changed document for string representation, as it was dependent on window, added translation function to return specific document element per target string, ex. "document.body".

I might have (probably) messed your formatting. Sorry!